### PR TITLE
Utilsから共通化メソッドの呼び出し方を修正

### DIFF
--- a/app/src/main/java/com/android/bookmanager_kotlin/activity/AddBookActivity.kt
+++ b/app/src/main/java/com/android/bookmanager_kotlin/activity/AddBookActivity.kt
@@ -15,7 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import com.android.bookmanager_kotlin.R
 import com.android.bookmanager_kotlin.R.id.bt_save
-import com.android.bookmanager_kotlin.util.DatePickerUtils.showDatePicker
+import com.android.bookmanager_kotlin.util.DatePickerUtils
 import com.android.bookmanager_kotlin.util.KeyboardUtils
 import com.android.bookmanager_kotlin.util.ValidationUtils
 import kotlinx.android.synthetic.main.activity_add_book.*
@@ -33,7 +33,7 @@ class AddBookActivity : AppCompatActivity() {
         }
 
         et_add_book_purchase_date.setOnClickListener {
-            showDatePicker(this, et_add_book_purchase_date)
+            DatePickerUtils.showDatePicker(this, et_add_book_purchase_date)
         }
     }
 

--- a/app/src/main/java/com/android/bookmanager_kotlin/fragment/EditBookFragment.kt
+++ b/app/src/main/java/com/android/bookmanager_kotlin/fragment/EditBookFragment.kt
@@ -15,7 +15,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.setFragmentResultListener
 import com.android.bookmanager_kotlin.R
 import com.android.bookmanager_kotlin.R.id.bt_save
-import com.android.bookmanager_kotlin.util.DatePickerUtils.showDatePicker
+import com.android.bookmanager_kotlin.util.DatePickerUtils
 import com.android.bookmanager_kotlin.util.FragmentUtils
 import com.android.bookmanager_kotlin.util.ValidationUtils
 import kotlinx.android.synthetic.main.fragment_edit_book.*
@@ -54,7 +54,7 @@ class EditBookFragment : Fragment() {
 
         // onCreateView()で呼ぶとnullポになる
         et_edit_book_purchase_date.setOnClickListener {
-            showDatePicker(requireContext(), et_edit_book_purchase_date)
+            DatePickerUtils.showDatePicker(requireContext(), et_edit_book_purchase_date)
         }
     }
 


### PR DESCRIPTION
object 宣言 { } からメソッドを呼び出す際は、object名.メソッド名 の形で呼び出すように修正した。

close #66 